### PR TITLE
Aws provider patch

### DIFF
--- a/development/_provider.tf
+++ b/development/_provider.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "development"
-  version = "~> 2"
+  version = "2.50"
 }
 
 terraform {

--- a/development/_provider.tf
+++ b/development/_provider.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "development"
+  version = "~> 2"
 }
 
 terraform {

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -1,5 +1,5 @@
 module "s3_bucket" {
-  source = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/archive/v1.5.0.zip//terraform-aws-s3-bucket-1.5.0"
+  source = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/archive/v1.10.0.zip//terraform-aws-s3-bucket-1.10.0"
 
   bucket = var.s3_bucket
   acl    = "private"

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -1,5 +1,5 @@
 module "s3_bucket" {
-  source = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/archive/v1.10.0.zip//terraform-aws-s3-bucket-1.10.0"
+  source = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/archive/v1.9.0.zip//terraform-aws-s3-bucket-1.9.0"
 
   bucket = var.s3_bucket
   acl    = "private"

--- a/production/_provider.tf
+++ b/production/_provider.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "production"
-  version = "~> 2"
+  version = "2.50"
 }
 
 terraform {

--- a/production/_provider.tf
+++ b/production/_provider.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "production"
+  version = "~> 2"
 }
 
 terraform {


### PR DESCRIPTION
Segment datalake is incompatible with default version of aws terraform which is now version 3, so set this to version 2 for now