### PR TITLE
[E2 Migration]update to correct account id for cross account prod

### DIFF
--- a/production/main.tf
+++ b/production/main.tf
@@ -46,7 +46,7 @@ module "s3_bucket" {
   source    = "../modules/s3_bucket"
   s3_bucket = local.s3_bucket_name
   tags = local.default_tags
-  data_account = 409386690817
+  data_account = 787212289020
 }
 
 module "iam" {


### PR DESCRIPTION
The prod account was pointing to dev-dataisland

This changes the job to point to the prod dataisland account: 787212289020